### PR TITLE
feat: visitable_group: allow to specify custom super bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,9 +290,10 @@ To illustrate, the typical visit loop would look like, given a `MyVisitor: ListV
 - calls `<MyVisitor as ListVisitor>::visit(v, &x.field)` on each field of `x`, completing the loop.
 
 The options available for the `visitable_group` macro are:
-- `visitor(drive_method_name(&[mut]TraitName)[, infallible])`: derive a visitor trait named `TraitName`.
+- `visitor(drive_method_name(&[mut]TraitName)[, infallible][, bounds(Bound1 + Bound2)])`: derive a visitor trait named `TraitName`.
   - the presence of `mut` determines whether the `TraitName` visitor will operate on mutable or immutable borrows.
-  - the optional `infallible` flag enables an infallible-style interface for the visitor:, where its methods `visit_$ty` return `()` instead of `ControlFlow<_>`.
+  - the optional `infallible` flag enables an infallible-style interface for the visitor, where its methods `visit_$ty` return `()` instead of `ControlFlow<_>`.
+  - the optional `bounds(...)` adds super trait bounds to the generated `TraitName` trait.
 - `drive(Ty)` and `skip(Ty)`: behave the same as their counterparts in the `Visit` and `VisitMut`
     derives described above.
 - `override(Ty)`: generates `enter_ty` and `exit_ty` methods that do nothing, and a `visit_ty`

--- a/derive_generic_visitor/src/lib.rs
+++ b/derive_generic_visitor/src/lib.rs
@@ -318,9 +318,10 @@
 //! - calls `<MyVisitor as ListVisitor>::visit(v, &x.field)` on each field of `x`, completing the loop.
 //!
 //! The options available for the `visitable_group` macro are:
-//! - `visitor(drive_method_name(&[mut]TraitName)[, infallible])`: derive a visitor trait named `TraitName`.
+//! - `visitor(drive_method_name(&[mut]TraitName)[, infallible][, bounds(Bound1 + Bound2)])`: derive a visitor trait named `TraitName`.
 //!   - the presence of `mut` determines whether the `TraitName` visitor will operate on mutable or immutable borrows.
-//!   - the optional `infallible` flag enables an infallible-style interface for the visitor:, where its methods `visit_$ty` return `()` instead of `ControlFlow<_>`.
+//!   - the optional `infallible` flag enables an infallible-style interface for the visitor, where its methods `visit_$ty` return `()` instead of `ControlFlow<_>`.
+//!   - the optional `bounds(...)` adds super trait bounds to the generated `TraitName` trait.
 //! - `drive(Ty)` and `skip(Ty)`: behave the same as their counterparts in the `Visit` and `VisitMut`
 //!     derives described above.
 //! - `override(Ty)`: generates `enter_ty` and `exit_ty` methods that do nothing, and a `visit_ty`

--- a/derive_generic_visitor/tests/visitable_group.rs
+++ b/derive_generic_visitor/tests/visitable_group.rs
@@ -49,53 +49,77 @@ fn infallible_visitable_group() {
     assert!(sum.0 == 42);
 }
 
+/// An arena-based AST where `Expr` is an index into an `ExprKind` arena. The visitor uses
+/// `bounds(HasArena)` so that the generated `AstVisitor` trait requires arena access, enabling a
+/// manual `AstVisitable` impl for `Expr` that resolves indices through the arena.
 #[test]
 fn visitable_group_with_super_bounds() {
     use std::collections::HashMap;
 
-    trait HasEnv {
-        fn env(&self) -> &HashMap<String, usize>;
+    type ExprId = usize;
+
+    #[derive(Clone)]
+    struct Expr(ExprId);
+
+    #[derive(Clone, Drive)]
+    enum ExprKind {
+        Literal(usize),
+        Var(String),
+        Add(Expr, Expr),
     }
 
-    #[derive(Drive, DriveMut)]
-    struct Id(String);
-    #[derive(Drive, DriveMut)]
-    enum Expr {
-        Literal(usize),
-        Var(Id),
+    trait HasArena {
+        fn arena(&self) -> &HashMap<ExprId, ExprKind>;
     }
 
     #[visitable_group(
-        visitor(drive_mut(&mut AstVisitor), infallible, bounds(HasEnv)),
+        visitor(drive(&AstVisitor), infallible, bounds(HasArena)),
         skip(usize, String),
-        override(Expr),
-        override_skip(Id),
+        override(ExprKind),
     )]
     trait AstVisitable {}
 
-    /// Inlines variables found in the environment as literals.
-    struct InlineVars {
-        env: HashMap<String, usize>,
-    }
-    impl HasEnv for InlineVars {
-        fn env(&self) -> &HashMap<String, usize> {
-            &self.env
-        }
-    }
-    impl AstVisitor for InlineVars {
-        fn exit_expr(&mut self, expr: &mut Expr) {
-            if let Expr::Var(Id(name)) = expr {
-                if let Some(&val) = self.env().get(name.as_str()) {
-                    *expr = Expr::Literal(val);
-                }
+    // Manually implement `AstVisitable` for `Expr`: look up the arena to visit the `ExprKind`.
+    impl AstVisitable for Expr {
+        fn drive<V: AstVisitor>(&self, v: &mut V) {
+            if let Some(kind) = v.arena().get(&self.0).cloned() {
+                v.visit(&kind);
             }
         }
     }
 
-    let mut expr = Expr::Var(Id("x".into()));
-    let mut visitor = InlineVars {
-        env: HashMap::from([("x".into(), 42)]),
+    /// Collects all variable names encountered in the AST.
+    struct CollectVars {
+        arena: HashMap<ExprId, ExprKind>,
+        vars: Vec<String>,
+    }
+    impl HasArena for CollectVars {
+        fn arena(&self) -> &HashMap<ExprId, ExprKind> {
+            &self.arena
+        }
+    }
+    impl AstVisitor for CollectVars {
+        fn enter_expr_kind(&mut self, kind: &ExprKind) {
+            if let ExprKind::Var(name) = kind {
+                self.vars.push(name.clone());
+            }
+        }
+    }
+
+    // Build a small arena: `add(x, add(y, 1))`
+    let arena = HashMap::from([
+        (0, ExprKind::Var("x".into())),
+        (1, ExprKind::Var("y".into())),
+        (2, ExprKind::Literal(1)),
+        (3, ExprKind::Add(Expr(1), Expr(2))),
+        (4, ExprKind::Add(Expr(0), Expr(3))),
+    ]);
+
+    let mut visitor = CollectVars {
+        arena: arena,
+        vars: vec![],
     };
-    visitor.visit(&mut expr);
-    assert!(matches!(expr, Expr::Literal(42)));
+    visitor.visit(&Expr(4));
+    visitor.vars.sort();
+    assert_eq!(visitor.vars, vec!["x", "y"]);
 }

--- a/derive_generic_visitor/tests/visitable_group.rs
+++ b/derive_generic_visitor/tests/visitable_group.rs
@@ -48,3 +48,54 @@ fn infallible_visitable_group() {
     });
     assert!(sum.0 == 42);
 }
+
+#[test]
+fn visitable_group_with_super_bounds() {
+    use std::collections::HashMap;
+
+    trait HasEnv {
+        fn env(&self) -> &HashMap<String, usize>;
+    }
+
+    #[derive(Drive, DriveMut)]
+    struct Id(String);
+    #[derive(Drive, DriveMut)]
+    enum Expr {
+        Literal(usize),
+        Var(Id),
+    }
+
+    #[visitable_group(
+        visitor(drive_mut(&mut AstVisitor), infallible, bounds(HasEnv)),
+        skip(usize, String),
+        override(Expr),
+        override_skip(Id),
+    )]
+    trait AstVisitable {}
+
+    /// Inlines variables found in the environment as literals.
+    struct InlineVars {
+        env: HashMap<String, usize>,
+    }
+    impl HasEnv for InlineVars {
+        fn env(&self) -> &HashMap<String, usize> {
+            &self.env
+        }
+    }
+    impl AstVisitor for InlineVars {
+        fn exit_expr(&mut self, expr: &mut Expr) {
+            if let Expr::Var(Id(name)) = expr {
+                if let Some(&val) = self.env().get(name.as_str()) {
+                    *expr = Expr::Literal(val);
+                }
+            }
+        }
+    }
+
+    let mut expr = Expr::Var(Id("x".into()));
+    let mut visitor = InlineVars {
+        env: HashMap::from([("x".into(), 42)]),
+    };
+    visitor.visit(&mut expr);
+    assert!(matches!(expr, Expr::Literal(42)));
+}

--- a/derive_generic_visitor_macros/src/visitable_group.rs
+++ b/derive_generic_visitor_macros/src/visitable_group.rs
@@ -16,6 +16,7 @@ struct VisitorDef {
     mutability: Option<Token![mut]>,
     faillible: bool,
     attrs: Vec<Attribute>,
+    super_bounds: Vec<syn::TypeParamBound>,
 }
 
 #[derive(Default)]
@@ -43,6 +44,37 @@ mod parse {
         syn::custom_keyword!(skip);
         syn::custom_keyword!(infallible);
         syn::custom_keyword!(override_skip);
+        syn::custom_keyword!(bounds);
+    }
+
+    /// Optional settings that follow the main `visitor(method_name(&[mut] TraitName), ...)` args.
+    enum VisitorOpt {
+        Infallible(#[allow(unused)] kw::infallible),
+        Bounds {
+            #[allow(unused)]
+            kw: kw::bounds,
+            #[allow(unused)]
+            paren: token::Paren,
+            bounds: Punctuated<syn::TypeParamBound, Token![+]>,
+        },
+    }
+
+    impl Parse for VisitorOpt {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(kw::infallible) {
+                Ok(VisitorOpt::Infallible(input.parse()?))
+            } else if lookahead.peek(kw::bounds) {
+                let content;
+                Ok(VisitorOpt::Bounds {
+                    kw: input.parse()?,
+                    paren: parenthesized!(content in input),
+                    bounds: Punctuated::parse_terminated(&content)?,
+                })
+            } else {
+                Err(lookahead.error())
+            }
+        }
     }
 
     #[allow(unused)]
@@ -69,7 +101,7 @@ mod parse {
             ref_tok: Token![&],
             mutability: Option<Token![mut]>,
             trait_name: Ident,
-            infallible: Option<(Token![,], kw::infallible)>,
+            opts: Punctuated<VisitorOpt, Token![,]>,
         },
         /// `drive` and `override` set which types are part of the group and whether the visitor
         /// traits are allowed to override the visiting behavior of those types. The syntax is
@@ -121,10 +153,11 @@ mod parse {
                     ref_tok: content2.parse()?,
                     mutability: content2.parse()?,
                     trait_name: content2.parse()?,
-                    infallible: if content.peek(Token![,]) {
-                        Some((content.parse()?, content.parse()?))
+                    opts: if content.peek(Token![,]) {
+                        let _: Token![,] = content.parse()?;
+                        Punctuated::parse_terminated(&content)?
                     } else {
-                        None
+                        Punctuated::new()
                     },
                 }
             } else {
@@ -145,16 +178,29 @@ mod parse {
                         trait_name,
                         method_name,
                         mutability,
-                        infallible,
                         attrs,
+                        opts,
                         ..
-                    } => options.visitors.push(VisitorDef {
-                        vis_trait_name: trait_name,
-                        method_name,
-                        mutability,
-                        faillible: infallible.is_none(),
-                        attrs,
-                    }),
+                    } => {
+                        let mut faillible = true;
+                        let mut super_bounds = vec![];
+                        for opt in opts {
+                            match opt {
+                                VisitorOpt::Infallible(_) => faillible = false,
+                                VisitorOpt::Bounds { bounds, .. } => {
+                                    super_bounds.extend(bounds);
+                                }
+                            }
+                        }
+                        options.visitors.push(VisitorDef {
+                            vis_trait_name: trait_name,
+                            method_name,
+                            mutability,
+                            faillible,
+                            attrs,
+                            super_bounds,
+                        });
+                    }
                     SetVisitableTypes { kind, tys, .. } => {
                         for ty in tys {
                             let kind = match kind {
@@ -254,10 +300,8 @@ pub fn impl_visitable_group(options: Options, mut item: ItemTrait) -> Result<Tok
 
     // Define a wrapper type that implements `Visit[Mut]` to pass through the `Drive[Mut]` API.
     let wrapper_name = Ident::new(&format!("{trait_name}Wrapper"), Span::call_site());
-    let infallible_wrapper_name = Ident::new(
-        &format!("{trait_name}InfallibleWrapper"),
-        Span::call_site(),
-    );
+    let infallible_wrapper_name =
+        Ident::new(&format!("{trait_name}InfallibleWrapper"), Span::call_site());
     let visitor_wrappers = {
         let define_struct = |wrapper_name: &Ident| {
             quote!(
@@ -336,6 +380,7 @@ pub fn impl_visitable_group(options: Options, mut item: ItemTrait) -> Result<Tok
             mutability,
             faillible,
             attrs,
+            super_bounds,
         } = vis_def;
         let return_type = faillible.then_some(quote!(-> #control_flow<Self::Break>));
         let return_type_val = if *faillible {
@@ -367,7 +412,10 @@ pub fn impl_visitable_group(options: Options, mut item: ItemTrait) -> Result<Tok
                 }
             }
         };
-        let visitor_constraints = faillible.then_some(quote!(Visitor+));
+        let visitor_constraints = faillible
+            .then_some(quote!(Visitor))
+            .into_iter()
+            .chain(super_bounds.iter().map(|b| quote!(#b)));
         let visit_by_val_infallible = faillible.then_some(quote!(
             /// Convenience when the visitor does not return early.
             fn visit_by_val_infallible<T: #trait_name>(self, x: & #mutability T) -> Self
@@ -386,7 +434,7 @@ pub fn impl_visitable_group(options: Options, mut item: ItemTrait) -> Result<Tok
         };
         let mut visitor_trait: ItemTrait = parse_quote! {
             #(#attrs)*
-            #vis trait #vis_trait_name: #visitor_constraints Sized where  {
+            #vis trait #vis_trait_name: #(#visitor_constraints + )* Sized where  {
                 /// Visit a visitable type. This calls the appropriate method of this trait on `x`
                 /// (`visit_$ty` if it exists, `visit_inner` if not).
                 fn visit<'a, T: #trait_name>(&'a mut self, x: & #mutability T)


### PR DESCRIPTION
This commit allows for custom bounds in the `visitable_group` macro, e.g.:

```rust
#[visitor(drive_mut(&mut AstVisitor), infallible, bounds(HasEnv)),
    skip(usize, String),
    override(Expr),
    override_skip(Id),
)]
trait AstVisitable {}
```

This will generate a HasEnv visitor trait with a super bound `HasEnv`.

This enables visitors to provide methods that can be used in the custom implementation of the driver trait.